### PR TITLE
Add  Udemy and Cloudflare

### DIFF
--- a/src/data/sites.ts
+++ b/src/data/sites.ts
@@ -65,6 +65,11 @@ export const websites = [
     name: "Trello",
     url: `https://trello.status.atlassian.com/${base_url_atlassian}`,
   },
+  {
+    name: "Udemy",
+    url: `https://status.udemy.com/${base_url_atlassian}`,
+  },
+
 
   // Websites by Incident.io
   // {

--- a/src/data/sites.ts
+++ b/src/data/sites.ts
@@ -69,6 +69,10 @@ export const websites = [
     name: "Udemy",
     url: `https://status.udemy.com/${base_url_atlassian}`,
   },
+  {
+    name: "Cloudflare",
+    url: `https://www.cloudflarestatus.com/${base_url_atlassian}`,
+  },
 
 
   // Websites by Incident.io


### PR DESCRIPTION
Add udemy and cloudflare website in sites list.

udemy status page: https://status.udemy.com/
udemy api url: https://status.udemy.com/api/v2/summary.json

cloudflare status page: https://www.cloudflarestatus.com/
cloudflare api url: https://www.cloudflarestatus.com/api/v2/summary.json